### PR TITLE
Add sad path test for admin editting their own information

### DIFF
--- a/app/models/loan.rb
+++ b/app/models/loan.rb
@@ -11,9 +11,4 @@ class Loan < ActiveRecord::Base
                     styles: { medium: "800x300#", thumb: "320x150#" },
                     default_url: "https://s3.amazonaws.com/turing-denvestments/assets/Richard_Stallman_by_Anders_Brenna_01.jpg"
   validates_attachment_content_type :avatar, content_type: /\Aimage\/.*\Z/
-
-  def avatar_remote_url(url)
-    self.avatar = URI.parse(url)
-    @avatar_remote_url
-  end
 end

--- a/app/views/admin/admins/edit.html.erb
+++ b/app/views/admin/admins/edit.html.erb
@@ -1,3 +1,5 @@
+<%= flash[:notice] %>
+
 <div class="container">
   <%= form_for :admin, url: "/admin/edit",
                        method: :put,

--- a/spec/features/admin_can_edit_own_attributes_spec.rb
+++ b/spec/features/admin_can_edit_own_attributes_spec.rb
@@ -28,4 +28,19 @@ feature "Admin editing profile" do
     visit "/admin/edit"
     expect(page).to have_content("The page you were looking for doesn't exist")
   end
+
+  scenario "fails with invalid attributes" do
+    log_in_as("admin", "password")
+    visit "/"
+    click_link "admin"
+    click_link "Edit My Profile"
+    fill_in "admin[username]", with: "alice"
+    fill_in "admin[password]", with: "password"
+    fill_in "admin[full_name]", with: "test full name"
+    fill_in "admin[address]", with: "987 test address"
+    click_on "Save Admin"
+
+    expect(current_path).to eq("/admin/edit")
+    expect(page).to have_content("Username has already been taken")
+  end
 end


### PR DESCRIPTION
We forgot a sad path for an admin editting their own information, so I added a test for that. Also removed a method from the `loan` model that wasn't being used. I think we added it for paperclip, but didn't end up having to use it. 100% coverage!!!